### PR TITLE
Disable flask debug reloader for auto instrumentation

### DIFF
--- a/integration-test-apps/auto-instrumentation/flask/create_flask_app.py
+++ b/integration-test-apps/auto-instrumentation/flask/create_flask_app.py
@@ -111,4 +111,9 @@ def get_flask_app_run_args():
     # will remove automatically-introduced instrumentation! Filing issue
     # upstream:
     # https://github.com/open-telemetry/opentelemetry-python-contrib/issues/546
-    return {"host": host, "port": int(port), "debug": False}
+    return {
+        "host": host,
+        "port": int(port),
+        "debug": True,
+        "use_reloader": False,
+    }


### PR DESCRIPTION
# Description

After further investigation, we found out in https://github.com/open-telemetry/opentelemetry-python-contrib/issues/546 how to isolate the fix needed to make auto instrumentation work with a `debug=True` flask app.

We need to set `use_reloader=False`.

See also [this Slack thread](https://cloud-native.slack.com/archives/C01PD4HUVBL/p1619633516200700?thread_ts=1619554719.189400&cid=C01PD4HUVBL).