### PR TITLE
Add propagator env to auto instrumentation app

### DIFF
--- a/integration-test-apps/auto-instrumentation/flask/Dockerfile
+++ b/integration-test-apps/auto-instrumentation/flask/Dockerfile
@@ -12,4 +12,4 @@ ENV HOME=/
 
 ENV OTEL_RESOURCE_ATTRIBUTES='service.name=aws-sample-auto-app'
 
-CMD opentelemetry-instrument --trace-exporter otlp --id-generator aws_xray python3 application.py
+CMD OTEL_PROPAGATORS=aws_xray opentelemetry-instrument --id-generator aws_xray python3 application.py

--- a/integration-test-apps/auto-instrumentation/flask/requirements.txt
+++ b/integration-test-apps/auto-instrumentation/flask/requirements.txt
@@ -7,6 +7,5 @@ flask~=1.0
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-instrumentation
-opentelemetry-distro
-opentelemetry-exporter-otlp
+opentelemetry-distro[otlp] # also installs opentelemetry-exporter-otlp
 opentelemetry-sdk-extension-aws


### PR DESCRIPTION
# Description

While we had set the propagators in the manual app using code, we set it using the `OTEL_PROPAGATORS` environment variable for the automatic instrumentation example.

It should have been enabled before and this way it is as automatic as possible.

