### PR TITLE
Set the propagator automatically using env variables

### DIFF
--- a/integration-test-apps/auto-instrumentation/flask/application.py
+++ b/integration-test-apps/auto-instrumentation/flask/application.py
@@ -18,7 +18,7 @@ from create_flask_app import app, get_flask_app_run_args
 # Setup AWS X-Ray Propagator
 
 # Propagators can be set using environment variable: OTEL_PROPAGATORS = aws_xray
-propagate.set_global_textmap(AwsXRayFormat())
+# propagate.set_global_textmap(AwsXRayFormat())
 
 if __name__ == "__main__":
     app.run(**get_flask_app_run_args())


### PR DESCRIPTION
Because we set the environment variable, we shouldn't need to set the propagators explicitly for the auto instrumentation app:

https://github.com/aws-observability/aws-otel-python/blob/e52469365d6f5055b4784f385f9ca5f1a6bea3a6/integration-test-apps/auto-instrumentation/flask/Dockerfile#L15