### PR TITLE
Manual App clones OTel Repos in Dockerfile not workflow

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -16,15 +16,6 @@ jobs:
       APP_PATH: integration-test-apps/${{ matrix.instrumentation-type}}-instrumentation/${{ matrix.app-platform }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: open-telemetry/opentelemetry-python
-          path: ${{ env.APP_PATH }}/opentelemetry-python-core
-      - uses: actions/checkout@v2
-        if: ${{ matrix.instrumentation-type }} == manual
-        with:
-          repository: open-telemetry/opentelemetry-python-contrib
-          path: ${{ env.APP_PATH }}/opentelemetry-python-contrib
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/integration-test-apps/manual-instrumentation/flask/Dockerfile
+++ b/integration-test-apps/manual-instrumentation/flask/Dockerfile
@@ -4,6 +4,10 @@ WORKDIR /app
 
 COPY . .
 
+RUN git clone https://github.com/open-telemetry/opentelemetry-python.git opentelemetry-python-core
+
+RUN git clone https://github.com/open-telemetry/opentelemetry-python-contrib.git opentelemetry-python-contrib
+
 RUN pip install -r requirements.txt
 
 ENV HOME=/


### PR DESCRIPTION
# Description

Instead of installing the `opentelemtry-python-core` and `opentelemetry-python-contrib` GitHub repos as part of the Integration Tests workflow, we install as part of the manual app's `Dockerfile` RUN commands since it is the only one that needs these repos. (It tests against the very latest code).