### PR TITLE
Adds "none" instrumentation app for performance reference

### DIFF
--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         app-platform: [ flask ]
-        instrumentation-type: [ auto, manual ]
+        instrumentation-type: [ auto, manual, none ]
     env:
       # NOTE: The configuration of `APP_PATH` is repo dependent
       APP_PATH: integration-test-apps/${{ matrix.instrumentation-type}}-instrumentation/${{ matrix.app-platform }}
@@ -65,7 +65,8 @@ jobs:
           echo '/usr/local/bin/python3 application.py' | tee --append $GITHUB_ENV;
           echo 'EOF' >> $GITHUB_ENV
       - name: Configure Manual Instrumentation-Type Specific Values
-        if: ${{ matrix.instrumentation-type == 'manual' }}
+        if: ${{ matrix.instrumentation-type == 'manual' ||
+          matrix.instrumentation-type == 'none' }}
         run: |
           echo 'APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE<<EOF' >> $GITHUB_ENV
           echo '/usr/local/bin/python3 /app/application.py' | tee --append $GITHUB_ENV;

--- a/integration-test-apps/auto-instrumentation/flask/README.md
+++ b/integration-test-apps/auto-instrumentation/flask/README.md
@@ -14,7 +14,7 @@ The application uses [Flask](https://flask.palletsprojects.com/en/1.1.x/) to exp
 
 ## Running the integration testing application:
 
-For more information on running a python application using automatic instrumentation, please refer to the [ADOT Python Manual Instrumentation Documentation](https://aws-otel.github.io/docs/getting-started/python-sdk/trace-auto-instr). In this context, the ADOT Collector is being run locally as a sidecar.
+For more information on running a python application using automatic instrumentation, please refer to the [ADOT Python Auto Instrumentation Documentation](https://aws-otel.github.io/docs/getting-started/python-sdk/trace-auto-instr). In this context, the ADOT Collector is being run locally as a sidecar.
 
 Option 1: Use the utility shell script to run the application in a local docker container `integration-test-apps/run_integration_test_app.sh flask auto`
 

--- a/integration-test-apps/none-instrumentation/flask/Dockerfile
+++ b/integration-test-apps/none-instrumentation/flask/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.9
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install -r requirements.txt
+
+ENV HOME=/
+
+ENV OTEL_RESOURCE_ATTRIBUTES='service.name=aws-sample-none-app'
+
+CMD python3 application.py

--- a/integration-test-apps/none-instrumentation/flask/README.md
+++ b/integration-test-apps/none-instrumentation/flask/README.md
@@ -1,0 +1,19 @@
+# AWS Distro for OpenTelemetry Python - Integration Testing App - None-instrumentation - Flask
+
+This application provides a baseline for performance testing. It has no instrumentation and so when compared against apps that do have instrumentation, it helps reveal the overhead that comes with instrumentation.
+
+## Application interface
+
+The application uses [Flask](https://flask.palletsprojects.com/en/1.1.x/) to expose the following routes:
+1. `/`
+    - Ensures the application is running.
+2. `/outgoing-http-call`
+    - Makes a HTTP request to `aws.amazon.com` using the popular `requests` Python library.
+3. `/aws-sdk-call`
+    - Makes a call to AWS S3 to list buckets for the account corresponding to the provided AWS credentials.
+
+## Running the integration testing application:
+
+Expects [the ADOT Collector](https://aws-otel.github.io/docs/getting-started/collector) to be running locally as a sidecar.
+
+Use `python3` to run the application directly in your terminal: `LISTEN_ADDRESS=127.0.0.1:8080 python3 integration-test-apps/none-instrumentation/flask/application.py`

--- a/integration-test-apps/none-instrumentation/flask/application.py
+++ b/integration-test-apps/none-instrumentation/flask/application.py
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Baseline Performance Reference App
+
+from create_flask_app import app, get_flask_app_run_args
+
+if __name__ == "__main__":
+    app.run(**get_flask_app_run_args())

--- a/integration-test-apps/none-instrumentation/flask/create_flask_app.py
+++ b/integration-test-apps/none-instrumentation/flask/create_flask_app.py
@@ -1,0 +1,85 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+import os
+import random
+import time
+
+import boto3
+import requests
+from flask import Flask, session
+import logging
+
+if os.environ.get('SAMPLE_APP_LOG_LEVEL') == 'ERROR':
+    log = logging.getLogger('werkzeug')
+    log.setLevel(logging.ERROR)
+
+# Constants
+
+DUMMY_TRACE_ID = 0x01234567890123456789012345678901
+REQUEST_START_TIME = "requestStartTime"
+
+# Setup Flask App
+
+app = Flask(__name__)
+app.secret_key = "aws-otel-python"
+
+
+def convert_otel_trace_id_to_xray(otel_trace_id_decimal):
+    otel_trace_id_hex = "{:032x}".format(otel_trace_id_decimal)
+    x_ray_trace_id = "-".join(
+        [
+            "1",
+            otel_trace_id_hex[:8],
+            otel_trace_id_hex[8:],
+        ]
+    )
+    return '{{"traceId": "{}"}}'.format(x_ray_trace_id)
+
+
+@app.before_request
+def before_request_func():
+    session[REQUEST_START_TIME] = int(time.time() * 1_000)
+
+
+def mimicPayloadSize():
+    return random.randrange(1000)
+
+
+@app.after_request
+def after_request_func(response):
+    return response
+
+
+@app.route("/outgoing-http-call")
+def call_http():
+    requests.get("https://aws.amazon.com/")
+
+    return app.make_response(
+        convert_otel_trace_id_to_xray(
+            DUMMY_TRACE_ID
+        )
+    )
+
+
+@app.route("/aws-sdk-call")
+def call_aws_sdk():
+    client = boto3.client("s3")
+    client.list_buckets()
+
+    return app.make_response(
+        convert_otel_trace_id_to_xray(
+            DUMMY_TRACE_ID
+        )
+    )
+
+
+# Test Root Endpoint
+@app.route("/")
+def root_endpoint():
+    return "<h1>App running!</h1>"
+
+
+def get_flask_app_run_args():
+    host, port = os.environ["LISTEN_ADDRESS"].split(":")
+    return {"host": host, "port": int(port), "debug": True}

--- a/integration-test-apps/none-instrumentation/flask/requirements.txt
+++ b/integration-test-apps/none-instrumentation/flask/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+requests
+flask


### PR DESCRIPTION
# Description

Following the same pattern as the `auto`, and `manual` instrumentation apps, we add this `none` instrumentation app so that it can be Soak Tested too. That way, we can more easily compare the performance results of the apps with instrumentation against the app without any instrumentation.

**NOTE**: The Soak Tests on this repo still use [GitHub hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners) so we _cannot_ trust that these results are reproducible. The results should be taken with caution until we can add self-hosted runners to the repo.