### PR TITLE
Updates to Soak Tests 2

### DIFF
--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     image: ${APP_IMAGE}
     environment:
       - INSTANCE_ID
-      - LISTEN_ADDRESS
+      - LISTEN_ADDRESS=0.0.0.0:${LISTEN_ADDRESS_PORT}
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
@@ -44,6 +44,7 @@ services:
     build:
       context: ./load-generator
     environment:
+      - TARGET_ADDRESS=app:${LISTEN_ADDRESS_PORT}
       - TEST_DURATION_MINUTES
     depends_on:
       - otel

--- a/.github/docker-performance-tests/load-generator/Dockerfile
+++ b/.github/docker-performance-tests/load-generator/Dockerfile
@@ -4,4 +4,4 @@ ADD https://hey-release.s3.us-east-2.amazonaws.com/hey_linux_amd64 /usr/local/bi
 
 RUN chmod +x /usr/local/bin/hey
 
-CMD hey -z "$TEST_DURATION_MINUTES"m http://app:8080/outgoing-http-call
+CMD hey -z "$TEST_DURATION_MINUTES"m http://"$TARGET_ADDRESS"/outgoing-http-call

--- a/.github/docker-performance-tests/otel-collector/collector-config.yml
+++ b/.github/docker-performance-tests/otel-collector/collector-config.yml
@@ -74,6 +74,8 @@ service:
     metrics:
       receivers:
         - hostmetrics
+        # Metrics not very available
+        # - otlp
       processors:
         - filter
         - metricstransform

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -175,7 +175,7 @@ jobs:
         env:
           APP_IMAGE: ${{ fromJSON(steps.docker-image-metadata.outputs.json).tags[0] }}
           INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
-          LISTEN_ADDRESS: 0.0.0.0:8080
+          LISTEN_ADDRESS_PORT: 8080
           LOG_GROUP_NAME: otel-sdk-performance-tests
           TARGET_SHA: ${{ env.TARGET_SHA }}
           # Also uses:
@@ -241,9 +241,9 @@ jobs:
           --target-sha ${{ env.TARGET_SHA }}
           --github-run-id ${GITHUB_RUN_ID}
           --test-duration-minutes ${{ env.TEST_DURATION_MINUTES }}
-      - name: Is this the first time we run Performance Tests for this commit?
+      - name: Do we already have Performance Test graph results for this commit?
         continue-on-error: true
-        id: check-is-first-time-reporting-commit
+        id: check-already-have-performance-results
         run: |
           git checkout gh-pages;
           HAS_RESULTS_ALREADY=$(
@@ -255,7 +255,7 @@ jobs:
             " || echo false
           );
           git checkout main;
-          [[ $HAS_RESULTS_ALREADY == false ]]
+          [[ $HAS_RESULTS_ALREADY == true ]]
       - name: Graph and Report Performance Test Averages result
         uses: NathanielRN/github-action-benchmark@v1.8.3-alpha3
         continue-on-error: true
@@ -272,7 +272,7 @@ jobs:
           # comment-always: true
           fail-on-alert: true
           auto-push: ${{ github.event_name == 'schedule' &&
-            steps.check-is-first-time-reporting-commit.outcome == 'success' &&
+            steps.check-already-have-performance-results.outcome == 'failure' &&
             github.ref == 'refs/heads/main' }}
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: soak-tests/per-commit-overall-results


### PR DESCRIPTION
# Description

Adds a few small updates to the Soak Tests

* Fix performance tests not publishing to graph if `data.js` file does not exist
* Make the `LISTEN_ADDRESS_PORT` configurable by the Soak Tests, not the whole `LISTEN_ADDRESS`
* Add a comment to anticipate metrics `otlp` receiver (not available in Python yet)