### PR TITLE
Updates to Soak Tests 3

### DIFF
--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
       - OTEL_EXPORTER_OTLP_ENDPOINT=grpc://otel:4317
     ports:
-      - '8080:8080'
+      - '${LISTEN_ADDRESS_PORT}:${LISTEN_ADDRESS_PORT}'
 
   load-generator:
     build:

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -15,7 +15,7 @@ on:
         required: true
         default: 300
   schedule:
-    - cron: '0 */24 * * *'
+    - cron: '0 15 * * *'
 env:
   # NOTE: The configuration of `APP_PROCESS_EXECUTABLE_NAME` is repo dependent
   APP_PROCESS_EXECUTABLE_NAME: python3
@@ -224,6 +224,7 @@ jobs:
             --instrumentation-type ${{ matrix.instrumentation-type }} \
             --max-benchmarks-to-keep ${{ env.MAX_BENCHMARKS_TO_KEEP }} \
             --github-repository ${GITHUB_REPOSITORY}
+          echo "::warning::Checkout Snapshots at this link: https://github.com/${GITHUB_REPOSITORY}/blob/gh-pages/soak-tests/snapshots/${{ env.TARGET_SHA }}";
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com";
           git config user.name "GitHub Actions";
           git fetch;


### PR DESCRIPTION
# Description

Additional small updates to the Soak Tests:
* Run at 8am PST instead of 5pm PST to make it easier to respond to quickly (tests take 5 hours so they run from 8am -> 1pm PST)
* Output a link to the folder which has the snapshots which were just generated (but not the snapshots themselves to not make that part too complicated)
* Make exposed port on `docker-compose.yml` file more generic by using the `LISTEN_ADDRESS_PORT` environment variable instead.