### PR TITLE
Do not publish snapshots on Soak Tests

### DIFF
--- a/.github/docker-performance-tests/alarms-poller/Dockerfile
+++ b/.github/docker-performance-tests/alarms-poller/Dockerfile
@@ -12,4 +12,4 @@ CMD python ./poll_during_performance_tests.py --logs-namespace $LOGS_NAMESPACE \
                                               --github-run-id $GITHUB_RUN_ID \
                                               --cpu-load-threshold $CPU_LOAD_THRESHOLD \
                                               --total-memory-threshold $TOTAL_MEMORY_THRESHOLD \
-                                              --image-suffix $IMAGE_SUFFIX
+                                              --matrix-commit-combo $MATRIX_COMMIT_COMBO

--- a/.github/docker-performance-tests/alarms-poller/poll_during_performance_tests.py
+++ b/.github/docker-performance-tests/alarms-poller/poll_during_performance_tests.py
@@ -76,16 +76,17 @@ def parse_args():
     )
 
     parser.add_argument(
-        "--image-suffix",
+        "--matrix-commit-combo",
         required=True,
         help="""
-        The image suffix which uniquely defines this Sample app by its platform
-        used, its instrumentation type, and the commit SHA from which it was
-        built. Used to create a unique name for the Performance Test Alarms.
+        The matrix + commit combination which uniquely defines this Sample app
+        by its platform used, its instrumentation type, and the commit SHA from
+        which it was built. Used to create a unique name for the Performance
+        Test Alarms.
 
         Examples:
 
-            --image-suffix=flask-auto-12345abcdef38e38678a59da0911c9abcde12345
+            --matrix-commit-combo=flask-auto-12345abcdef38e38678a59da0911c9abcde12345
         """,
     )
 
@@ -132,7 +133,7 @@ if __name__ == "__main__":
         aws_client = boto3.client("cloudwatch")
 
         unique_alarm_name_component = (
-            f"{args.image_suffix}-{args.github_run_id}"
+            f"{args.matrix_commit_combo}-{args.github_run_id}"
         )
 
         cpu_load_alarm_name = f"{CPU_LOAD_ALARM_NAME_PREFIX} ({unique_alarm_name_component}) Sample App"

--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - HOSTMETRICS_INTERVAL_SECS
       - LOG_GROUP_NAME
       - LOGS_NAMESPACE
-      - IMAGE_SUFFIX
+      - MATRIX_COMMIT_COMBO
       - APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE
       - APP_PROCESS_EXECUTABLE_NAME
     volumes:
@@ -26,7 +26,8 @@ services:
     user: "${UID}:${GID}"
 
   app:
-    image: ${APP_IMAGE}
+    build:
+      context: ../../${APP_PATH}
     environment:
       - INSTANCE_ID
       - LISTEN_ADDRESS=0.0.0.0:${LISTEN_ADDRESS_PORT}
@@ -66,7 +67,7 @@ services:
       - CPU_LOAD_THRESHOLD
       - TOTAL_MEMORY_THRESHOLD
       - GITHUB_RUN_ID
-      - IMAGE_SUFFIX
+      - MATRIX_COMMIT_COMBO
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     depends_on:

--- a/.github/docker-performance-tests/otel-collector/collector-config.yml
+++ b/.github/docker-performance-tests/otel-collector/collector-config.yml
@@ -46,7 +46,7 @@ exporters:
     region: ${AWS_DEFAULT_REGION}
     namespace: ${LOGS_NAMESPACE}
     log_group_name: ${LOG_GROUP_NAME}
-    log_stream_name: sample-app-${IMAGE_SUFFIX}
+    log_stream_name: sample-app-${MATRIX_COMMIT_COMBO}
     resource_to_telemetry_conversion:
       enabled: true
     dimension_rollup_option: NoDimensionRollup
@@ -74,7 +74,7 @@ service:
     metrics:
       receivers:
         - hostmetrics
-        # Metrics not very available
+        # Metrics not yet available
         # - otlp
       processors:
         - filter

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -37,7 +37,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
       issues: write
     strategy:
       fail-fast: false
@@ -109,51 +108,9 @@ jobs:
 
     # MARK: - Build and Push Sample App
 
-      # WARNING: In an edge case, if two jobs use the same commit at the same
-      # time, they will share an `IMAGE_SUFFIX` and race to push and pull Docker
-      # Images!
-      - name: Create Image Suffix
+      - name: Create unique combination using matrix + commit parameters
         run: |
-          echo "IMAGE_SUFFIX=${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}-${{ env.TARGET_SHA }}" | tee --append $GITHUB_ENV;
-      - name: Log in to the GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ env.TARGET_SHA }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Extract metadata (tags, labels) for Docker
-        id: docker-image-metadata
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ghcr.io/${{ github.repository }}-sample-app-${{ env.IMAGE_SUFFIX }}
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-      # TODO: Instead of building, publishing, and pulling a Sample App Docker
-      # Image in `docker-compose`. Could we just build the image in
-      # `docker-compose` directly using `build/context`? We would lose the
-      # public Docker Image but we would avoid polluting the published packages
-      # and anyone could build from the commit if they wanted to.
-      - name: Build and Push Docker image
-        uses: docker/build-push-action@v2
-        with:
-          push: true
-          context: ${{ env.APP_PATH }}
-          tags: ${{ steps.docker-image-metadata.outputs.tags }}
-          labels: ${{ steps.docker-image-metadata.outputs.labels }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          echo "MATRIX_COMMIT_COMBO=${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}-${{ env.TARGET_SHA }}" | tee --append $GITHUB_ENV;
 
     # MARK: - Run Performance Tests
 
@@ -173,12 +130,12 @@ jobs:
         continue-on-error: true
         working-directory: .github/docker-performance-tests
         env:
-          APP_IMAGE: ${{ fromJSON(steps.docker-image-metadata.outputs.json).tags[0] }}
           INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
           LISTEN_ADDRESS_PORT: 8080
           LOG_GROUP_NAME: otel-sdk-performance-tests
-          TARGET_SHA: ${{ env.TARGET_SHA }}
           # Also uses:
+          # APP_PATH
+          # TARGET_SHA
           # LOGS_NAMESPACE
           # LOG_STREAM_NAME
           # APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE
@@ -189,7 +146,7 @@ jobs:
           # CPU_LOAD_THRESHOLD
           # TOTAL_MEMORY_THRESHOLD
           # AWS_DEFAULT_REGION
-          # IMAGE_SUFFIX
+          # MATRIX_COMMIT_COMBO
           # GITHUB_RUN_ID
         run: |-
           docker-compose up --build;


### PR DESCRIPTION
# Description

Do not publish snapshots (Docker Images of the Sample apps) during Soak Tests. The Soak Tests should just be testing the snapshots that were created during the main integration workflow.

To remedy this _right now_, we build the snapshots directly from the path where the Docker Sample Apps are and use that during performance testing. This eliminates the visibility that we got from the published snapshot, but is no issue at all because we can reproduce results easily using commits and the same `docker build` process.

As _a follow-up_, we can implement "pull"-ing of the the snapshot from the main build.