### PR TITLE
Updates to Soak Tests 4

### DIFF
--- a/.github/auto-issue-templates/failure-after-soak_tests.md
+++ b/.github/auto-issue-templates/failure-after-soak_tests.md
@@ -11,7 +11,7 @@ After the Soak Tests completed, a performance degradation was revealed for commi
 
 Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/{{ sha }}). These are the snapshots for the violating commit:
 
-![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/{{ sha }}/{{ env.APP_PLATFORM }}-{{ env.INSTRUMENTATION_TYPE }}-cpu-load-soak-{{ env.GITHUB_RUN_ID }}.png?raw=true)
-![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/{{ sha }}/{{ env.APP_PLATFORM }}-{{ env.INSTRUMENTATION_TYPE }}-total-memory-soak-{{ env.GITHUB_RUN_ID }}.png?raw=true)
+![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-cpu-load.png?raw=true)
+![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-total-memory.png?raw=true)
 
 The threshold violation should also be noticeable on [our graph of Soak Test average results per commit](https://{{ repo.owner }}.github.io/{{ repo.repo }}/soak-tests/per-commit-overall-results/index.html).

--- a/.github/auto-issue-templates/failure-during-soak_tests.md
+++ b/.github/auto-issue-templates/failure-during-soak_tests.md
@@ -11,5 +11,5 @@ During Soak Tests execution, a performance degradation was revealed for commit {
 
 Snapshots of the Soak Test run are available [on the gh-pages branch](https://github.com/{{ env.GITHUB_REPOSITORY }}/tree/gh-pages/soak-tests/snapshots/{{ sha }}). These are the snapshots for the violating commit:
 
-![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/{{ sha }}/{{ env.APP_PLATFORM }}-{{ env.INSTRUMENTATION_TYPE }}-cpu-load-soak-{{ env.GITHUB_RUN_ID }}.png?raw=true)
-![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/{{ sha }}/{{ env.APP_PLATFORM }}-{{ env.INSTRUMENTATION_TYPE }}-total-memory-soak-{{ env.GITHUB_RUN_ID }}.png?raw=true)
+![CPU Load Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-cpu-load.png?raw=true)
+![Total Memory Soak Test SnapShot Image](https://github.com/{{ env.GITHUB_REPOSITORY }}/blob/gh-pages/soak-tests/snapshots/commits/{{ sha }}/runs/{{ env.GITHUB_RUN_ID }}/{{ env.APP_PLATFORM }}/{{ env.INSTRUMENTATION_TYPE }}-total-memory.png?raw=true)

--- a/.github/scripts/performance-tests/get-metric-data/produce_performance_test_results.py
+++ b/.github/scripts/performance-tests/get-metric-data/produce_performance_test_results.py
@@ -32,8 +32,8 @@ def parse_args():
         required=True,
         type=int,
         help="""
-        The duration of the performance test, which is used to determine the
-        start of metrics to include in the snapshots.
+        The duration of the performance test. Used as the starting point for
+        determining which metrics to include in the performance test results.
 
         Examples:
 

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -22,8 +22,8 @@ env:
   AWS_DEFAULT_REGION: us-east-1
   DEFAULT_TEST_DURATION_MINUTES: 300
   HOSTMETRICS_INTERVAL_SECS: 600
-  CPU_LOAD_THRESHOLD: 71
-  TOTAL_MEMORY_THRESHOLD: 2147483648
+  CPU_LOAD_THRESHOLD: 75
+  TOTAL_MEMORY_THRESHOLD: 2684354560 # 2.5 GiB
   MAX_BENCHMARKS_TO_KEEP: 100
   # TODO: We might be able to adapt the "Soak Tests" to be "Overhead Tests".
   # This means monitoring the Sample App's performance using high levels of TPS
@@ -106,7 +106,7 @@ jobs:
           repository: open-telemetry/opentelemetry-python-contrib
           path: ${{ env.APP_PATH }}/opentelemetry-python-contrib
 
-    # MARK: - Build and Push Sample App
+    # MARK: - Uniquely identify this Sample App environment
 
       - name: Create unique combination using matrix + commit parameters
         run: |
@@ -181,13 +181,13 @@ jobs:
             --instrumentation-type ${{ matrix.instrumentation-type }} \
             --max-benchmarks-to-keep ${{ env.MAX_BENCHMARKS_TO_KEEP }} \
             --github-repository ${GITHUB_REPOSITORY}
-          echo "::warning::Checkout Snapshots at this link: https://github.com/${GITHUB_REPOSITORY}/blob/gh-pages/soak-tests/snapshots/${{ env.TARGET_SHA }}";
+          echo "::warning::Checkout Snapshots at this link: https://github.com/${GITHUB_REPOSITORY}/blob/gh-pages/soak-tests/snapshots/commits/${{ env.TARGET_SHA }}/runs/${GITHUB_RUN_ID}/${{ matrix.app-platform }}";
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com";
           git config user.name "GitHub Actions";
           git fetch;
           git checkout gh-pages;
-          git add soak-tests/snapshots;
-          git commit -m "Adding Soak Tests Snapshots from ${{ env.TARGET_SHA }}";
+          git add soak-tests/snapshots/commits;
+          git commit -m "Soak Test Snapshots from ${{ env.TARGET_SHA }} - ${GITHUB_RUN_ID}";
           git push;
           git checkout main;
       - name: Prepare Performance Test results as JSON output


### PR DESCRIPTION
# Description

We currently post snapshots at a path that doesn't separate by `GITHUB_RUN_ID` or `app-platform`. Because we run on a schedule, this will make the directories get rather large. The `app-platform` not so much because we probably won't have too many Sample Apps but it does still add up.

To fix this we make directories out of the parameters so that the size of the directories is at most the combinations of `(instrumentation-type, metric-type)`.