### PR TITLE
Use GitHub Repo Image registry instead of ECR

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -7,6 +7,8 @@ jobs:
   publish_apps:
     name: Publish and Test Apps
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -37,10 +39,12 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 1200
           aws-region: us-east-1
-      - name: Login to ECR
+      - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: public.ecr.aws
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
@@ -50,13 +54,16 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - name: Build docker image
+      - name: Construct Sample App image tag
+        run: |
+          echo "APP_IMAGE=ghcr.io/${{ github.repository }}/sample-app-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}:${{ github.sha }}" | tee --append $GITHUB_ENV;
+      - name: Build and Push Docker image
         uses: docker/build-push-action@v2
         with:
           push: true
           context: ${{ env.APP_PATH }}
           tags: |
-            public.ecr.aws/aws-otel-test/python-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}:${{ github.sha }}
+            ${{ env.APP_IMAGE }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Run test containers
@@ -65,7 +72,7 @@ jobs:
         env:
           INSTANCE_ID: ${{ github.run_id }}-${{ github.run_number }}
           LISTEN_ADDRESS: 0.0.0.0:8080
-          APP_IMAGE: public.ecr.aws/aws-otel-test/python-${{ matrix.app-platform }}-${{ matrix.instrumentation-type }}:${{ github.sha }}
+          APP_IMAGE: ${{ env.APP_IMAGE }}
           # TODO: (NathanielRN) Once metrics are updated in OTel Python, update this
           # to also validate metrics integration. See https://github.com/open-telemetry/opentelemetry-python/issues/1835
           VALIDATOR_COMMAND: -c default-otel-trace-validation.yml --endpoint http://app:8080 --metric-namespace default -t ${{ github.run_id }}-${{ github.run_number }}


### PR DESCRIPTION
# Description

~In https://github.com/aws-observability/aws-otel-python/pull/26 we removed the GitHub Registry publishing step because Soak Tests shouldn't be pushing Images.~

~In this PR, we add it back as a part of the Integration Test workflow. In the future, workflows like the Soak Tests could pull the image published by the Integration Test.~

Constantly creating images of the Sample App using the latest packages from OpenTelemetry Python upstream helps us validate our AWS components still work with any new changes. Currently, we publish those images ECR.

Publishing to ECR is a problem because it requires an AWS account to publish the image. Further, viewing the images requires going to `public.ecr.aws` which is less obvious. In this PR we remove those pain points by using GHCR (GitHub Container Registry) which only requires a `GITHUB_TOKEN` with the `packages: write` permissions to upload images. Then, these images are accessible directly from the repo homepages for anyone interested in seeing more information about.