### PR TITLE
Small edits to the Soak Tests

### DIFF
--- a/.github/scripts/performance-tests/produce_metric_widget_images.py
+++ b/.github/scripts/performance-tests/produce_metric_widget_images.py
@@ -366,17 +366,21 @@ if __name__ == "__main__":
             f"Will create a snapshot at URL: https://github.com/{args.github_repository}/blob/gh-pages/{snapshot_location}",
         )
 
-    # Delete oldest snapshots
+    # Delete oldest run folders in most recent commit and oldest commit folders
 
-    snapshot_dirs_length = len(os.listdir(SOAK_TESTS_SNAPSHOTS_COMMITS_DIR))
+    for snapshots_dir in [
+        SOAK_TESTS_SNAPSHOTS_COMMITS_DIR,
+        f"{SOAK_TESTS_SNAPSHOTS_COMMITS_DIR}/{ args.target_sha }/runs",
+    ]:
+        snapshot_dirs_length = len(os.listdir(snapshots_dir))
 
-    if snapshot_dirs_length > args.max_benchmarks_to_keep:
-        oldest_snapshot_dirs = nsmallest(
-            snapshot_dirs_length - args.max_benchmarks_to_keep,
-            Path(SOAK_TESTS_SNAPSHOTS_COMMITS_DIR).iterdir(),
-            key=os.path.getmtime,
-        )
-        for old_snapshots_dir in oldest_snapshot_dirs:
-            shutil.rmtree(old_snapshots_dir, ignore_errors=True)
+        if snapshot_dirs_length > args.max_benchmarks_to_keep:
+            oldest_snapshot_dirs = nsmallest(
+                snapshot_dirs_length - args.max_benchmarks_to_keep,
+                Path(snapshots_dir).iterdir(),
+                key=os.path.getmtime,
+            )
+            for old_snapshots_dir in oldest_snapshot_dirs:
+                shutil.rmtree(old_snapshots_dir, ignore_errors=True)
 
     logger.info("Done creating metric widget images.")

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -245,7 +245,7 @@ jobs:
         with:
           filename: .github/auto-issue-templates/failure-during-soak_tests.md
       - name: Publish Issue if failed AFTER Performance Tests
-        uses: NathanielRN/create-an-issue@v2.5.1-alpha2
+        uses: JasonEtco/create-an-issue@v2
         if: ${{ github.event_name == 'schedule' &&
           steps.check-failure-after-performance-tests.outcome == 'failure' }}
         env:


### PR DESCRIPTION
# Description

Follow up to #27, we make some small edits to the Soak Tests:
1. Delete oldest snapshots in the `commits/<current_commit_id>/runs/` folder as well as the `commits/` folder.
2. With https://github.com/JasonEtco/create-an-issue/pull/114 merged, we can use the upstream JasonEtco/create-an-issue action again! (This will be broken until the next minor release)