### PR TITLE
Use http protocol for OTel Exporter endpoint

### DIFF
--- a/.github/docker-performance-tests/docker-compose.yml
+++ b/.github/docker-performance-tests/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - AWS_DEFAULT_REGION
       - SAMPLE_APP_LOG_LEVEL=ERROR
       - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
-      - OTEL_EXPORTER_OTLP_ENDPOINT=grpc://otel:4317
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://otel:4317
     ports:
       - '${LISTEN_ADDRESS_PORT}:${LISTEN_ADDRESS_PORT}'
 

--- a/.github/workflows/soak-testing.yml
+++ b/.github/workflows/soak-testing.yml
@@ -134,10 +134,12 @@ jobs:
           LISTEN_ADDRESS_PORT: 8080
           LOG_GROUP_NAME: otel-sdk-performance-tests
           # Also uses:
+          # AWS_ACCESS_KEY_ID
+          # AWS_SECRET_ACCESS_KEY
+          # AWS_SESSION_TOKEN
           # APP_PATH
           # TARGET_SHA
           # LOGS_NAMESPACE
-          # LOG_STREAM_NAME
           # APP_PROCESS_COMMAND_LINE_DIMENSION_VALUE
           # APP_PROCESS_EXECUTABLE_NAME
           # HOSTMETRICS_INTERVAL_SECS


### PR DESCRIPTION
# Description

Since Java `requires` that the protocol be `http`, Go only allows `http`, we add this protocol for consistency among the languages.

Also, update the list of environment variables used by the apps when they are Soak Tested.