### PR TITLE
Update manual sample app with OTel Python propagator package

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ following links.
 - [OpenTelemetry Python Core GitHub](https://github.com/open-telemetry/opentelemetry-python)
 - [OpenTelemetry Python Contrib GitHub](https://github.com/open-telemetry/opentelemetry-python-contrib)
 - [AWS OpenTelemetry Python SDK Extension Package](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/sdk-extension/opentelemetry-sdk-extension-aws)
+- [AWS OpenTelemetry Python X-Ray Propagator Package](https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/propagator/opentelemetry-propagator-aws-xray)
 - [AWS Distro for OpenTelemetry](https://aws-otel.github.io/)
 
 ## Security

--- a/integration-test-apps/manual-instrumentation/flask/application.py
+++ b/integration-test-apps/manual-instrumentation/flask/application.py
@@ -19,12 +19,13 @@ from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
+# AWS X-Ray Propagator Components
+
+from opentelemetry.propagators.aws import AwsXRayPropagator
+
 # AWS X-Ray SDK Extension Components
 
 from opentelemetry.sdk.extension.aws.trace import AwsXRayIdGenerator
-from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import (
-    AwsXRayFormat,
-)
 # from opentelemetry.sdk.resources import get_aggregated_resources
 # from opentelemetry.sdk.extension.aws.resource.ec2 import (
 #     AwsEc2ResourceDetector,
@@ -37,7 +38,7 @@ from create_flask_app import app, get_flask_app_run_args
 # Setup AWS X-Ray Propagator
 
 # Propagators can be set using environment variable: OTEL_PROPAGATORS = xray
-propagate.set_global_textmap(AwsXRayFormat())
+propagate.set_global_textmap(AwsXRayPropagator())
 
 # Setup Tracer
 

--- a/integration-test-apps/manual-instrumentation/flask/create_flask_app.py
+++ b/integration-test-apps/manual-instrumentation/flask/create_flask_app.py
@@ -10,7 +10,7 @@ import requests
 from flask import Flask, session
 import logging
 from opentelemetry import trace
-from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import (
+from opentelemetry.aws.propagators.aws_xray_propagator import (
     TRACE_ID_DELIMITER,
     TRACE_ID_FIRST_PART_LENGTH,
     TRACE_ID_VERSION,

--- a/integration-test-apps/manual-instrumentation/flask/requirements.txt
+++ b/integration-test-apps/manual-instrumentation/flask/requirements.txt
@@ -10,6 +10,7 @@ flask
 ./opentelemetry-python-core/exporter/opentelemetry-exporter-otlp-proto-grpc
 ./opentelemetry-python-core/exporter/opentelemetry-exporter-otlp
 ./opentelemetry-python-contrib/sdk-extension/opentelemetry-sdk-extension-aws
+./opentelemetry-python-contrib/propagator/opentelemetry-propagator-aws-xray
 ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-botocore
 ./opentelemetry-python-contrib/util/opentelemetry-util-http
 ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-requests


### PR DESCRIPTION
# Description

Taking in the changes from upstream:
- https://github.com/open-telemetry/opentelemetry-python-contrib/pull/720
- https://github.com/open-telemetry/opentelemetry-python-contrib/pull/729

These changes were done to split the propagator into its own package. This was necessary for it to not depend on the `opentelemetry-sdk` package. It cannot depend on this because our `AwsLambdaInstrumentor` package will depend on the propagator and instrumentation should only depend on the` opentelemetry-api` package.