### PR TITLE
Fix X-Ray propagators import in manual instrumentation sample app

### DIFF
--- a/integration-test-apps/manual-instrumentation/flask/create_flask_app.py
+++ b/integration-test-apps/manual-instrumentation/flask/create_flask_app.py
@@ -10,7 +10,7 @@ import requests
 from flask import Flask, session
 import logging
 from opentelemetry import trace
-from opentelemetry.aws.propagators.aws_xray_propagator import (
+from opentelemetry.propagators.aws.aws_xray_propagator import (
     TRACE_ID_DELIMITER,
     TRACE_ID_FIRST_PART_LENGTH,
     TRACE_ID_VERSION,


### PR DESCRIPTION
# Description

Follow up to #38, one of the imports I had was incorrect because it had `.aws.` in the wrong path. This change adds the correct path.