### PR TITLE
Update auto integ test app for new propagator pkg

### DIFF
--- a/integration-test-apps/auto-instrumentation/flask/create_flask_app.py
+++ b/integration-test-apps/auto-instrumentation/flask/create_flask_app.py
@@ -10,7 +10,7 @@ import requests
 from flask import Flask, session
 import logging
 from opentelemetry import trace
-from opentelemetry.sdk.extension.aws.trace.propagation.aws_xray_format import (
+from opentelemetry.propagators.aws.aws_xray_propagator import (
     TRACE_ID_DELIMITER,
     TRACE_ID_FIRST_PART_LENGTH,
     TRACE_ID_VERSION,

--- a/integration-test-apps/auto-instrumentation/flask/requirements.txt
+++ b/integration-test-apps/auto-instrumentation/flask/requirements.txt
@@ -3,4 +3,5 @@ requests
 flask
 
 opentelemetry-distro[otlp] # also installs opentelemetry-exporter-otlp
+opentelemetry-propagator-aws-xray
 opentelemetry-sdk-extension-aws


### PR DESCRIPTION
# Description

With the PyPI release of `opentelemetry-propagator-aws-xray`, we can actually take it as dependency in our app that showcases Auto Instrumentation with OTel Python.