### PR TITLE
Update manual app because OTel SDK no dep on OTel instrumentation pkg

### DIFF
--- a/integration-test-apps/manual-instrumentation/flask/requirements.txt
+++ b/integration-test-apps/manual-instrumentation/flask/requirements.txt
@@ -5,10 +5,10 @@ flask
 ./opentelemetry-python-core/opentelemetry-semantic-conventions
 ./opentelemetry-python-core/opentelemetry-proto
 ./opentelemetry-python-core/opentelemetry-api
-./opentelemetry-python-core/opentelemetry-instrumentation
 ./opentelemetry-python-core/opentelemetry-sdk
 ./opentelemetry-python-core/exporter/opentelemetry-exporter-otlp-proto-grpc
 ./opentelemetry-python-core/exporter/opentelemetry-exporter-otlp
+./opentelemetry-python-contrib/opentelemetry-instrumentation
 ./opentelemetry-python-contrib/sdk-extension/opentelemetry-sdk-extension-aws
 ./opentelemetry-python-contrib/propagator/opentelemetry-propagator-aws-xray
 ./opentelemetry-python-contrib/instrumentation/opentelemetry-instrumentation-botocore


### PR DESCRIPTION
Recently, upstream OTel Python moved `opentelemetry-instrumentation` to the contrib repo: https://github.com/open-telemetry/opentelemetry-python-contrib/pull/738

Our manual app uses the very latest of the repos so we detected this failure when the [Soak Test workflows started to fail](https://github.com/aws-observability/aws-otel-python/runs/3907462098?check_suite_focus=true#step:13:98).

This PR updates the manual app dependencies.