### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/.github/docker-performance-tests/alarms-poller/Dockerfile
+++ b/.github/docker-performance-tests/alarms-poller/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9
 
 COPY . .
 
-RUN pip install docker boto3
+RUN pip install --no-cache-dir docker boto3
 
 CMD python ./poll_during_performance_tests.py --logs-namespace $LOGS_NAMESPACE \
                                               --metrics-period $HOSTMETRICS_INTERVAL_SECS \

--- a/integration-test-apps/auto-instrumentation/flask/Dockerfile
+++ b/integration-test-apps/auto-instrumentation/flask/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 RUN opentelemetry-bootstrap --action=install
 

--- a/integration-test-apps/manual-instrumentation/flask/Dockerfile
+++ b/integration-test-apps/manual-instrumentation/flask/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENV HOME=/
 

--- a/integration-test-apps/none-instrumentation/flask/Dockerfile
+++ b/integration-test-apps/none-instrumentation/flask/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENV HOME=/
 


### PR DESCRIPTION
using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>