### PR TITLE
[ TESTING ] Added new metrics to match java SDK metrics parity

### DIFF
--- a/integration-test-apps/manual-instrumentation/flask/create_flask_app.py
+++ b/integration-test-apps/manual-instrumentation/flask/create_flask_app.py
@@ -22,7 +22,7 @@ if os.environ.get('SAMPLE_APP_LOG_LEVEL') == 'ERROR':
 
 # NOTE: (NathanielRN) Metrics is on hold.
 # See https://github.com/open-telemetry/opentelemetry-python/issues/1835
-# from setup_metrics import apiBytesSentCounter, apiLatencyRecorder
+from setup_metrics import apiBytesSentCounter, apiLatencyRecorder, apiqueueSizeChangeMetric, apitotalApiBytesSentMetric, apilastLatencyMetric
 
 # Constants
 
@@ -59,22 +59,22 @@ def mimicPayloadSize():
 
 @app.after_request
 def after_request_func(response):
-    # if request.path == "/outgoing-http-call":
-    #     apiBytesSentCounter.add(
-    #         response.calculate_content_length() + mimicPayloadSize(),
-    #         {
-    #             DIMENSION_API_NAME: request.path,
-    #             DIMENSION_STATUS_CODE: response.status_code,
-    #         },
-    #     )
+    if request.path == "/outgoing-http-call":
+        apiBytesSentCounter.add(
+            response.calculate_content_length() + mimicPayloadSize(),
+            {
+                DIMENSION_API_NAME: request.path,
+                DIMENSION_STATUS_CODE: response.status_code,
+            },
+        )
 
-    #     apiLatencyRecorder.record(
-    #         int(time.time() * 1_000) - session[REQUEST_START_TIME],
-    #         {
-    #             DIMENSION_API_NAME: request.path,
-    #             DIMENSION_STATUS_CODE: response.status_code,
-    #         },
-    #     )
+        apiLatencyRecorder.record(
+            int(time.time() * 1_000) - session[REQUEST_START_TIME],
+            {
+                DIMENSION_API_NAME: request.path,
+                DIMENSION_STATUS_CODE: response.status_code,
+            },
+        )
 
     return response
 

--- a/integration-test-apps/manual-instrumentation/flask/setup_metrics.py
+++ b/integration-test-apps/manual-instrumentation/flask/setup_metrics.py
@@ -21,23 +21,46 @@ meter = metrics.get_meter("aws-otel", "1.0")
 
 # Setup Metric Components
 
-apiBytesSentMetricName = "apiBytesSent"
 latencyMetricName = "latency"
+apiBytesSentMetricName = "apiBytesSent"
+totalApiBytesSentMetricName = "totalApiBytesSent"
+lastLatencyMetricName = "lastLatency"
+queueSizeChangeMetricName = "queueSizeChange"
+actualQueueSizeMetricName = "actualQueueSize"
 
 if "INSTANCE_ID" in os.environ:
     instanceId = os.environ["INSTANCE_ID"]
     if not instanceId.strip() == "":
         latencyMetricName += "_" + instanceId
         apiBytesSentMetricName += "_" + instanceId
+        totalApiBytesSentMetricName += "_" + instanceId
+        lastLatencyMetricName += "_" + instanceId
+        queueSizeChangeMetricName += "_" + instanceId
+        actualQueueSizeMetricName += "_" + instanceId
 
 apiBytesSentCounter = meter.create_counter(
     apiBytesSentMetricName, "API request load sent in bytes", "one", int
 )
 
-apiLatencyRecorder = meter.create_valuerecorder(
+apiLatencyRecorder = meter.create_histogram(
     latencyMetricName, "API latency time", "ms", int
 )
 
+apiqueueSizeChangeMetric = meter.create_up_down_counter(
+    queueSizeChangeMetricName, "Queue Size change", "one", int
+)
+
+apitotalApiBytesSentMetric = meter.create_observable_gauge(
+    totalApiBytesSentMetricName, "Total API request load sent in bytes", "one", int
+)
+
+apilastLatencyMetric = meter.create_observable_gauge(
+    lastLatencyMetricName, "The last API latency observed at collection interval", "ms", int
+)
+
+apiactualQueueSizeMetric = meter.create_observable_gauge(
+    actualQueueSizeMetricName, "The actual queue size observed at collection interval", "one", int
+)
 # Start Metric Pipeline
 
 # Exporter to export metrics to the console


### PR DESCRIPTION
**Description:** 

Added new metrics to match [java SDK metrics](https://github.com/aws-observability/aws-otel-java-instrumentation/blob/f64a093fe549c675669b389d253e54202fc316e6/sample-apps/spark/src/main/java/com/amazon/sampleapp/MetricEmitter.java) parity. These will be a series of updates to enable metrics emitter inside the `Manual-instrumentation` flask application 

**Testing:** 

Still under testing.



<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
